### PR TITLE
Quote MySQL field names for insert statement

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -37,7 +37,7 @@ func (e mysqlEngine) build(obj jwalk.ObjectWalker) (commands, error) {
 		if v, ok := value.(jwalk.ObjectsWalker); ok {
 			if err := v.Walk(func(obj jwalk.ObjectWalker) error {
 				values := make([]interface{}, 0)
-				insert := fmt.Sprintf("INSERT INTO %s (", table)
+				insert := fmt.Sprintf("INSERT INTO `%s` (", table)
 				valuesStr := "("
 
 				first := true

--- a/mysql.go
+++ b/mysql.go
@@ -50,7 +50,7 @@ func (e mysqlEngine) build(obj jwalk.ObjectWalker) (commands, error) {
 							valuesStr = valuesStr + ", "
 						}
 
-						insert = insert + field
+						insert = fmt.Sprintf("%s`%s`", insert, field)
 						valuesStr = valuesStr + "?"
 					}
 

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -22,21 +22,21 @@ func Test_mysqlEngine_build(t *testing.T) {
 			input: []byte(`{"users":[{"id":1,"name":"Roman"},{"id":2,"name":"Dmitry"}],"roles":[{"id":2,"role_ids":[1,2]}]}`),
 			expect: commands{
 				command{
-					q: "INSERT INTO users (id, name) VALUES (?, ?);",
+					q: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?);",
 					args: []interface{}{
 						float64(1),
 						"Roman",
 					},
 				},
 				command{
-					q: "INSERT INTO users (id, name) VALUES (?, ?);",
+					q: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?);",
 					args: []interface{}{
 						float64(2),
 						"Dmitry",
 					},
 				},
 				command{
-					q: "INSERT INTO roles (id, role_ids) VALUES (?, ?);",
+					q: "INSERT INTO `roles` (`id`, `role_ids`) VALUES (?, ?);",
 					args: []interface{}{
 						float64(2),
 						[]interface{}{
@@ -81,7 +81,7 @@ func Test_mysqlEngine_exec(t *testing.T) {
 			name: "valid query",
 			args: []command{
 				command{
-					q: "INSERT INTO users (id, name) VALUES (?, ?);",
+					q: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?);",
 					args: []interface{}{
 						1,
 						"Roman",
@@ -93,7 +93,7 @@ func Test_mysqlEngine_exec(t *testing.T) {
 			name: "invalid query",
 			args: []command{
 				command{
-					q: "INSERT INTO roles (id, name) VALUES (?, ?);",
+					q: "INSERT INTO `roles` (`id`, `name`) VALUES (?, ?);",
 					args: []interface{}{
 						1,
 						"User",


### PR DESCRIPTION
Closes #14 

Adds back ticks around MySQL field names, which will allow all names including MySQL reserved words to be used.