### PR TITLE
Escaping table names and fields for Postgres

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -209,6 +209,9 @@ CREATE TABLE IF NOT EXISTS users (
 	id integer NOT NULL, 
 	name varchar(255) NOT NULL
 );
+CREATE TABLE IF NOT EXISTS "all" (
+	"group" varchar(255) NOT NULL
+);
 `
 
 func newPG(pool *dockertest.Pool) (*pgDocker, error) {

--- a/polluter_test.go
+++ b/polluter_test.go
@@ -16,6 +16,11 @@ const (
   name: Roman
 - id: 2
   name: Dmitry`
+	pgInput = input + `
+all:
+- group: first
+- group: second
+  `
 )
 
 func TestNew(t *testing.T) {
@@ -140,7 +145,7 @@ func TestPollute(t *testing.T) {
 				db, teardown := preparePostgresDB(t)
 				return PostgresEngine(db), teardown
 			},
-			input: strings.NewReader(input),
+			input: strings.NewReader(pgInput),
 		},
 		{
 			name: "redis",

--- a/postgres.go
+++ b/postgres.go
@@ -30,6 +30,10 @@ func (e postgresEngine) exec(cmds []command) error {
 	return errors.Wrap(tx.Commit(), "commit")
 }
 
+func escape(name string) string {
+	return fmt.Sprintf(`"%s"`, name)
+}
+
 func (e postgresEngine) build(obj jwalk.ObjectWalker) (commands, error) {
 	cmds := make(commands, 0)
 
@@ -37,7 +41,7 @@ func (e postgresEngine) build(obj jwalk.ObjectWalker) (commands, error) {
 		if v, ok := value.(jwalk.ObjectsWalker); ok {
 			if err := v.Walk(func(obj jwalk.ObjectWalker) error {
 				values := make([]interface{}, 0)
-				insert := fmt.Sprintf("INSERT INTO %s (", table)
+				insert := fmt.Sprintf("INSERT INTO %s (", escape(table))
 				valuesStr := "("
 
 				first := true
@@ -51,7 +55,7 @@ func (e postgresEngine) build(obj jwalk.ObjectWalker) (commands, error) {
 							valuesStr = valuesStr + ", "
 						}
 
-						insert = insert + field
+						insert = insert + escape(field)
 						valuesStr = valuesStr + fmt.Sprintf("$%d", i+1)
 					}
 

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -22,21 +22,21 @@ func Test_postgresEngine_build(t *testing.T) {
 			input: []byte(`{"users":[{"id":1,"name":"Roman"},{"id":2,"name":"Dmitry"}],"roles":[{"id":2,"role_ids":[1,2]}]}`),
 			expect: commands{
 				command{
-					q: "INSERT INTO users (id, name) VALUES ($1, $2);",
+					q: `INSERT INTO "users" ("id", "name") VALUES ($1, $2);`,
 					args: []interface{}{
 						float64(1),
 						"Roman",
 					},
 				},
 				command{
-					q: "INSERT INTO users (id, name) VALUES ($1, $2);",
+					q: `INSERT INTO "users" ("id", "name") VALUES ($1, $2);`,
 					args: []interface{}{
 						float64(2),
 						"Dmitry",
 					},
 				},
 				command{
-					q: "INSERT INTO roles (id, role_ids) VALUES ($1, $2);",
+					q: `INSERT INTO "roles" ("id", "role_ids") VALUES ($1, $2);`,
 					args: []interface{}{
 						float64(2),
 						[]interface{}{
@@ -81,7 +81,7 @@ func Test_postgresEngine_exec(t *testing.T) {
 			name: "valid query",
 			args: []command{
 				command{
-					q: "INSERT INTO users (id, name) VALUES ($1, $2);",
+					q: `INSERT INTO "users" ("id", "name") VALUES ($1, $2);`,
 					args: []interface{}{
 						1,
 						"Roman",
@@ -93,7 +93,7 @@ func Test_postgresEngine_exec(t *testing.T) {
 			name: "invalid query",
 			args: []command{
 				command{
-					q: "INSERT INTO roles (id, name) VALUES ($1, $2);",
+					q: `INSERT INTO "roles" ("id", "name") VALUES ($1, $2);`,
 					args: []interface{}{
 						1,
 						"User",


### PR DESCRIPTION
When using [reserved keywords](https://www.postgresql.org/docs/8.1/sql-keywords-appendix.html) in either table names or field ones for Postgres, the DB will report a syntax error. Tried to escape those.